### PR TITLE
Support code area node

### DIFF
--- a/sphinx_markdown_builder/contexts.py
+++ b/sphinx_markdown_builder/contexts.py
@@ -352,6 +352,28 @@ class CodeContext(SubContext):
         return f'```cpp\n{content}\n```'
 
 
+class CodeAreaBlockContext(SubContext):
+    def __init__(self, params=SubContextParams(2, 2)):
+        super().__init__(params)
+
+    def make(self):
+        content = super().make()
+        if not content:
+            return ""
+        if content.find("<pre>") > -1:
+            start = content.find("<pre>")
+            end = content.find("</pre>") + len("</pre>")
+            return content[start:end]
+        if content.find("```") > -1:
+            # for the CodeAreaNodeContext, the text and the code are doubled
+            # we need to extract just the code portion and ignore
+            # the duplicated plain text.
+            start = content.find("```")
+            end = content.find("```", start + len("```")) + len("```")
+            return content[start:end]
+        else:
+            return f'{content}'
+
 class MetaContext(NoLineBreakContext):
     def __init__(self, name: str, params=SubContextParams(1, 1, target="head")):
         super().__init__("<br/>", params)

--- a/sphinx_markdown_builder/contexts.py
+++ b/sphinx_markdown_builder/contexts.py
@@ -341,6 +341,17 @@ class TitleContext(NoLineBreakContext):
         return f"{self.section_prefix} {content}"
 
 
+class CodeContext(SubContext):
+    def __init__(self, params=SubContextParams(2, 2)):
+        super().__init__(params)
+
+    def make(self):
+        content = super().make()
+        if not content:
+            return ""
+        return f'```cpp\n{content}\n```'
+
+
 class MetaContext(NoLineBreakContext):
     def __init__(self, name: str, params=SubContextParams(1, 1, target="head")):
         super().__init__("<br/>", params)

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -32,6 +32,7 @@ from docutils import languages, nodes
 from sphinx.util.docutils import SphinxTranslator
 
 from sphinx_markdown_builder.contexts import (
+    CodeAreaBlockContext,
     CodeContext,
     CommaSeparatedContext,
     ContextStatus,
@@ -294,6 +295,7 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     def unknown_visit(self, node):
         """Warn once per instance for unsupported nodes."""
         node_type = node.__class__.__name__
+
         if node_type not in self._warned:
             super().unknown_visit(node)
             self._warned.add(node_type)
@@ -471,6 +473,13 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         else:
             level = self.status.section_level
         self._push_context(TitleContext(level))
+
+    @pushing_context
+    def visit_CodeAreaNode(self, _node):
+        code_context = CodeAreaBlockContext()
+        code = _node.astext()
+        code_context.add(code)
+        self._push_context(code_context)
 
     @pushing_context
     @pushing_status

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -32,6 +32,7 @@ from docutils import languages, nodes
 from sphinx.util.docutils import SphinxTranslator
 
 from sphinx_markdown_builder.contexts import (
+    CodeContext,
     CommaSeparatedContext,
     ContextStatus,
     DocInfoContext,
@@ -622,8 +623,11 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         # We don't want methods to be at the same level as classes,
         # If signature has a non-null class, that's means it is a signature
         # of a class method
-        h_level = 4 if node.get("class", None) else 3
-        self._push_context(TitleContext(h_level))
+
+        code_context = CodeContext()
+        desc_signature = node.astext()
+        code_context.add(f"{desc_signature}")
+        self._push_context(code_context)
 
     def visit_desc_parameterlist(self, _node):
         self._push_context(WrappedContext("(", ")", wrap_empty=True))


### PR DESCRIPTION
In order to support Python Notebooks, we need to support `CodeAreaNode`
This code implements this functionality in a very crude way.

Please merge #1 first